### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^8.2",
         "filament/filament": "^5.0",
         "spatie/laravel-package-tools": "^1.16.4",
-        "illuminate/contracts": "^11.28 || ^12.0"
+        "illuminate/contracts": "^11.28 || ^12.0 || ^13.0"
     },
     "require-dev": {
         "filament/spatie-laravel-media-library-plugin": "^5.0",
@@ -33,7 +33,7 @@
         "larastan/larastan": "3.0",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^8.1",
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^3.7",
         "pestphp/pest-plugin-arch": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0"


### PR DESCRIPTION
## Summary

- Add `^13.0` to `illuminate/contracts` constraint to allow installation on Laravel 13
- Add `^11.0` to `orchestra/testbench` constraint for Laravel 13 test compatibility

No code changes required — the package uses stable Illuminate\Contracts interfaces with no version-specific conditionals.